### PR TITLE
docs: add context documents from GitHub issues and PRs

### DIFF
--- a/context-docs/07-business-use-cases-stakeholders.md
+++ b/context-docs/07-business-use-cases-stakeholders.md
@@ -1,0 +1,121 @@
+# Fi3ldMan - Business Use Cases & Stakeholders
+
+## Overview
+
+Fi3ldMan is a digital replacement for a classified/commercially sensitive field service manual used by acoustic analysts in the naval/maritime domain. The system catalogs naval platforms (ships/submarines) and their acoustic signatures, organized hierarchically by Region > Country > Category > Class. This document captures the business use cases and stakeholder needs derived from the project's GitHub issues and pull requests.
+
+## Domain Context
+
+The manual serves personnel who identify naval platforms by detecting and analyzing their acoustic emissions. Each platform class entry contains:
+
+- **Summary properties** (displacement, speed, dimensions)
+- **Acoustic signatures** (tonals/frequencies in structured tables)
+- **Propulsion system** details
+- **Images** (photographs, diagrams, spectrograms/"grams")
+- **Multimedia** (audio WAV files of acoustic signatures, video recordings)
+
+Three publication variants serve different audiences and purposes:
+
+| Publication | Purpose | Audience |
+|-------------|---------|----------|
+| **Pub-5** | Main reference manual — full platform data by region/country | Acoustic analysts/operators |
+| **Pub-9** | Redacted companion to Pub-10 — hides sensitive metadata | Partner organizations |
+| **Pub-10** | Operator training — interactive spectrogram ("gram") viewers and the "7 Questions" analysis framework | Training operators |
+
+## Primary Business Use Cases
+
+### 1. Platform Identification by Acoustic Signature
+
+The core use case. An operator detects an unknown frequency and must identify its source platform. This drives requirements for:
+
+- **Harmonics calculation** from shaft rate (SR) and corrected shaft rate (CSR)
+- **Frequency matching** with configurable precision (precise/standard/loose)
+- **Interactive spectrogram viewing** for pattern recognition training
+- **Sortable data tables** for rapid lookup across signature data
+
+*Key issues: #125, #126, #129–136, #139, #142*
+
+### 2. Selective Publishing for Partner Organizations
+
+The most operationally critical requirement. Partner organizations (defense contractors such as "Teledyne", "Axiomatic", "Banchio") hold maintenance contracts for specific nations or platforms and must receive filtered document exports that:
+
+- Include only countries/classes relevant to their contract
+- Exclude data where a competitor could bid independently
+- Carry custom protective markings and titles per export
+- Use an exclusion-based model (mark content to exclude rather than include)
+
+Filtering granularity operates at both country-level and class-level within a country. This drove adoption of DITA `audience` attributes and DITAVAL conditional processing.
+
+*Key issues: #6, #43, #105, #106*
+
+### 3. Advanced Search & Discovery
+
+Basic full-text search (provided by Oxygen WebHelp) is insufficient for analyst workflows. Requirements include:
+
+- **Frequency-range search** with sliders for tonal lookup
+- **Faceted filtering** with cascading Region > Country dropdowns
+- **Unit search** across all platform entries
+- **Search integration** with harmonics calculator (SR/CSR fields in search UI)
+- **Page promotion** (e.g., searching "Spain" should surface the Spain country page first)
+
+*Key issues: #10, #11, #13, #14, #18, #63, #114, #150*
+
+### 4. Change Tracking & Version Management
+
+Each release requires clear identification of what has changed:
+
+- Yellow marker images flag new or updated content
+- Markers record version provenance (which release introduced the change)
+- Bulk removal of previous release markers at each new version
+- "What's New" page collating all changes per release
+- Provenance tracking back to source reference spreadsheet IDs
+
+*Key issues: #7, #124*
+
+### 5. Information Security & Classification
+
+Every page must display appropriate security classification:
+
+- Configurable warning banners in header and footer
+- Customizable banner text and color per publication variant
+- Different protective markings for different export audiences
+- Corporate logo with link to index page
+
+*Key issues: #88, #89, #90*
+
+### 6. Multimedia Playback
+
+The manual includes embedded multimedia for signature recognition:
+
+- Audio player for acoustic signature WAV files (in signature remarks sections)
+- Video player for propulsion system recordings
+- Organized content directories: `content/images`, `content/audio`, `content/video`
+
+*Key issue: #17*
+
+## Stakeholders
+
+| Stakeholder | Role | Primary Needs |
+|-------------|------|---------------|
+| **Acoustic analysts/operators** | Primary end users | Frequency identification, gram viewing, advanced search, sortable tables |
+| **DITA authors** | Content maintainers | Intuitive OxygenXML editing, clear authoring procedures, version tracking |
+| **Security officers** | Information assurance | Configurable protective markings, controlled filtered exports |
+| **Partner organizations** | External recipients | Redacted Pub-9 exports scoped to their contract |
+| **Training operators** | Skill development | Pub-9/10 for acoustic feature recognition and the "7 Questions" framework |
+| **Project managers** | Oversight | What's New tracking, release provenance, change audit trail |
+
+## Key Domain Terminology
+
+| Term | Definition |
+|------|-----------|
+| **Class** | A type of naval platform (ship/submarine) — the primary unit of content |
+| **Installation** | Older/legacy term for "class" (renamed during the project) |
+| **Tonals** | Discrete acoustic frequencies emitted by a platform |
+| **SR** | Shaft Rate — base rotational frequency of a platform's propulsion |
+| **CSR** | Corrected Shaft Rate — adjusted shaft rate value |
+| **TPK** | Tones Per Knot — relates acoustic frequency to platform speed |
+| **Harmonics** | Integer multiples of a base frequency |
+| **Gram / GramFrame** | Spectrogram/waterfall display of acoustic data over time |
+| **7Q / Seven Questions** | Structured analysis framework for acoustic platform identification |
+| **Protective Marking** | Security classification label applied to document exports |
+| **What's New markers** | Visual indicators (yellow images) flagging changed content per release |

--- a/context-docs/08-legacy-migration-strategy.md
+++ b/context-docs/08-legacy-migration-strategy.md
@@ -1,0 +1,100 @@
+# Fi3ldMan - Legacy Migration Strategy
+
+## Overview
+
+Fi3ldMan replaces a legacy HTML-based field service manual (referred to as "LegacyMan"). The migration follows a deliberate two-phase strategy designed to unblock content authors quickly while deferring complex data structuring work. This document captures the migration approach, challenges, and pain points derived from the project's GitHub issues and pull requests.
+
+## Migration Phases
+
+### Phase 1: Coarse Conversion (Completed)
+
+**Goal**: Convert legacy HTML into general DITA and publish as Oxygen WebHelp Responsive, providing full-text search and modern web navigation.
+
+- Bulk-parse legacy HTML into standard DITA topics
+- Preserve content fidelity without detailed schema enforcement
+- Enable authors to begin editing in OxygenXML immediately
+- Publish via DITA-OT with WebHelp Responsive transtype
+
+The prior project "LegacyMan" handled the initial HTML-to-DITA parsing. Fi3ldMan picks up from that output.
+
+*Key issue: #16; Key PR: #107*
+
+### Phase 2: Detailed Specialization (Ongoing)
+
+**Goal**: Parse content into a specialized DITA schema with structured, machine-readable frequency data.
+
+- Create custom DTD specializations for domain elements (class, country, region, propulsion, related-links)
+- Parse frequency/tonal data from free text into structured arrays
+- Enable programmatic exploitation of signature data (search, harmonics calculation)
+- Support selective publishing through profiling attributes
+
+A "simple DITA" variant (without specialization) was later created to reduce the complexity barrier for authors.
+
+*Key PRs: #22, #24, #25, #35, #36, #53, #54, #55, #60, #77, #83, #84, #86, #87*
+
+## Schema Evolution
+
+The DITA information architecture evolved significantly during migration:
+
+| Change | Rationale |
+|--------|-----------|
+| "Installation" renamed to "Class" | Aligns with domain language used by analysts |
+| Custom DTD specializations created | Enable structured data and conditional processing |
+| Simple DITA variant introduced | Lower barrier for authors unfamiliar with specialization |
+| Categories added as intermediate grouping | Handle nations with many platform classes |
+| Related links at country and class levels | Replicate legacy cross-referencing |
+
+**Content hierarchy**: World > Region > Country > [Category] > Class
+
+Each class topic contains sections: summary (properties table), signatures (tonals table), propulsion, remarks, images.
+
+## Legacy Technology Challenges
+
+### Java Applet Conversion
+
+The legacy manual used **Java applets** for interactive spectrogram ("gram") viewers. These applets:
+
+- Display a background spectrogram image with time/frequency axes
+- Allow users to measure distances between acoustic features
+- Accept ~12 configuration parameters (image URL, axis limits, scale factors)
+
+Migration approach: decompile Java > understand parameter model > rewrite in JavaScript. The applets served Pub-9/10 content for operator training.
+
+*Key issues: #121, #151, #157, #159, #163*
+
+### Data Parsing Fragility
+
+Legacy frequency/harmonic data exists in many inconsistent text formats:
+
+- Ratio expressions: `135.2 x CSR`, `H2-4, **5**, 7`, mixed notations
+- Bold/dominant harmonic indicators embedded in text formatting
+- Whitespace-dependent layouts from legacy HTML used for visual alignment
+- No consistent schema for frequency table cell content
+
+Robust parsing was required to extract structured data from these formats.
+
+*Key issues: #130, #131, #133*
+
+### Layout and Formatting
+
+- Legacy HTML used extensive whitespace for visual layout — causes alignment issues in DITA
+- Image sizes inconsistent across class pages
+- Screen real estate competition: dense content (grams, tables, related links, search) on analyst workstations
+- Left-hand TOC removed since content has its own navigation structure
+
+*Key issues: #62, #110, #113*
+
+## Architecture Decision: DITA-Heavy vs React-Heavy
+
+An early architectural decision (Issue #8) chose **DITA-Heavy**: publish the entire document via DITA-OT and only use React/JavaScript for advanced interactive features (search, harmonics calculator). The alternative — a React-Admin heavy approach — was rejected in favor of keeping the publishing pipeline within the DITA ecosystem.
+
+## Deployment History
+
+| Platform | Purpose | Status |
+|----------|---------|--------|
+| Heroku | Static content serving trial | Abandoned |
+| `serve` (npm) | Local development server | Active |
+| GitHub Pages | Demo hosting | Active |
+| Oxygen WebHelp | Production publishing | Active |
+
+*Key issues: #30, #164; Key PR: #33*

--- a/context-docs/09-interactive-features-requirements.md
+++ b/context-docs/09-interactive-features-requirements.md
@@ -1,0 +1,127 @@
+# Fi3ldMan - Interactive Features: Requirements & User Needs
+
+## Overview
+
+This document captures the **requirements and user needs** behind Fi3ldMan's interactive JavaScript features, as expressed in GitHub issues and pull requests. For technical implementation details of existing features, see `05-interactive-features-javascript.md`.
+
+## Harmonics Calculator
+
+### User Story
+
+An acoustic analyst detects an unknown frequency and needs to determine which platform is producing it. The harmonics calculator enables rapid cross-referencing of observed frequencies against known signature data.
+
+### Requirements (from Issues #125, #126, #129–136, #139, #142)
+
+| Requirement | Detail |
+|-------------|--------|
+| SR/CSR entry | User enters Shaft Rate and/or Corrected Shaft Rate values |
+| Harmonic computation | Calculate all harmonics for each row in signature tables |
+| Observed frequency matching | Highlight table rows where computed harmonics match an entered frequency |
+| Dominant harmonic emphasis | Bold formatting for dominant harmonics (as marked in source data) |
+| Absolute frequency toggle | Switch between ratio-based and absolute frequency display |
+| Precision levels | Precise (±0.1 Hz), Standard (±1 Hz), Loose (±4 Hz) |
+| Speed calculator | `speed = SR / TPK` with auto-calculation of missing values |
+| Cross-page persistence | Calculator values stored in localStorage, available across page navigations |
+| Complex ratio parsing | Handle formats like `135.2 x CSR`, `H2-4, **5**, 7`, mixed notations |
+| Error reporting | Surface unparseable data to authors for correction |
+
+### Pain Points
+
+- Ratio/harmonic formats vary wildly across legacy content — no consistent notation
+- Some ratios reference SR, others CSR, others are absolute frequencies
+- Bold/dominant indicators embedded in HTML formatting rather than structured data
+
+## Interactive Gram Viewer
+
+### User Story
+
+Training operators study spectrogram ("gram") images to learn acoustic feature recognition. They need to interactively measure distances between features on the waterfall display, guided by the "7 Questions" analytical framework.
+
+### Requirements (from Issues #121, #151, #157, #158, #159, #163)
+
+| Requirement | Detail |
+|-------------|--------|
+| Spectrogram display | Render background gram image with calibrated time/frequency axes |
+| Measurement tool | Allow users to measure distances between features on the image |
+| Configuration parameters | ~12 params per gram: image URL, time/freq axis limits, scale factors |
+| 7Q integration | "Seven Questions" framework embedded alongside gram viewer on the same page |
+| Responsive layout | Scale wide gram images appropriately for laptop screens |
+| Legacy parity | Replicate functionality of original Java applets |
+
+### Migration Path
+
+Java applets → decompile → understand parameter model → rewrite in JavaScript. The GramFrame viewer is central to Pub-9/10 operator training content.
+
+## Faceted / Advanced Search
+
+### User Story
+
+Analysts need to find platform information by various criteria — not just free text. They may know a frequency range, a country, or a unit name, and need to narrow results efficiently.
+
+### Requirements (from Issues #10, #11, #13, #14, #18, #63, #114, #150)
+
+| Requirement | Detail |
+|-------------|--------|
+| Frequency search | Sliders for tonal frequency range lookup |
+| Cascading filters | Region > Country dropdowns that narrow as constraints are applied |
+| Unit search | Search across platform unit names |
+| Faceted narrowing | Available filter options reduce based on active constraints |
+| SR/CSR integration | Harmonics calculator fields available within search UI |
+| Page promotion | Searching "Spain" surfaces the Spain country page first |
+| JSON data index | Frequency/platform data extracted from published HTML into JSON for search indexing |
+
+### Libraries Considered
+
+`itemsjs`, `minisearch`, `react-admin` — evaluated during search design discussions.
+
+## Table Sorting
+
+### User Story
+
+Long signature data tables are difficult to scan. Analysts need to sort by platform name or by numerical frequency value.
+
+### Requirements (from Issue #122; PR #123)
+
+- Client-side sort capability on data tables
+- Sort by name (alphabetical) or by frequency (numerical)
+- JS-inserted sort buttons on table column headers
+- Used the `sorttable` open-source library
+
+## Abbreviation Tooltips
+
+### User Story
+
+Source data contains many acronyms that analysts may not immediately recognize. Hovering over an acronym should reveal its expansion.
+
+### Requirements (from Issue #14)
+
+- Abbreviations document provides canonical expansions
+- Tooltips appear on hover for acronym instances in published output
+- Supports the many source/equipment acronyms found in installation data
+
+## Dark Theme
+
+### User Story
+
+Analysts working in darkened environments (e.g., operations rooms) need a low-light display option.
+
+### Requirements (from Issue #12 — still open)
+
+- Light/dark toggle for published output
+- DITA-Bootstrap plugin already supports dark theme capability
+- Not yet implemented
+
+## Navigation & UX Enhancements
+
+### Requirements (from Issues #34, #37, #42, #62, #69, #92, #95, #96, #100, #101, #103)
+
+| Feature | Detail |
+|---------|--------|
+| World image-map | Clickable map for region navigation (replicating legacy) |
+| Region listing pages | Country tables with flag images per region |
+| In-page floating nav | Panel for jumping between class sections (summary, signatures, propulsion, remarks) |
+| Related links sidebar | Floating right-hand panel with external link indicators |
+| Search in header | Full-text search moved to header bar to save screen space |
+| Welcome page | Prominent "Regions" tile as primary entry point |
+| Gallery component | Image gallery at top of class pages |
+| Current page suppression | Don't show link to current page in navigation |

--- a/context-docs/10-content-authoring-publishing-workflows.md
+++ b/context-docs/10-content-authoring-publishing-workflows.md
@@ -1,0 +1,141 @@
+# Fi3ldMan - Content Authoring & Publishing Workflows
+
+## Overview
+
+This document captures the authoring workflows, selective publishing processes, and content management practices derived from the project's GitHub issues and pull requests. For technical template/build details, see `04-publishing-templates-build-system.md`.
+
+## Selective Publishing Workflow
+
+### Purpose
+
+Partner organizations hold maintenance contracts for specific nations or platforms. Each partner receives a filtered export of the manual containing only the content relevant to their contract, with appropriate security markings.
+
+### Known Partners (from Issues)
+
+Partners referenced in issues include "Teledyne", "Axiomatic", and "Banchio" — each with contracts scoped to specific countries or platform classes.
+
+### Filtering Model
+
+The system uses an **exclusion-based model**: content is marked for exclusion rather than inclusion.
+
+| Aspect | Detail |
+|--------|--------|
+| Mechanism | DITA `audience` attribute + DITAVAL conditional processing |
+| Granularity | Country-level and class-level within a country |
+| Custom per export | Protective marking text, banner color, document title |
+| Constraint | Must exclude data where a competitor could bid independently |
+
+### Process
+
+1. Author applies `audience` profiling attributes to content at country and class levels
+2. A DITAVAL filter file specifies which audience values to exclude for a given partner
+3. Oxygen DITA-OT build applies the filter, producing a subset publication
+4. Custom protective marking and title are set via build parameters
+
+*Key issues: #6, #43, #105, #106*
+
+## DITA Authoring in OxygenXML
+
+### Author Mode Customizations
+
+Several OxygenXML Author mode enhancements support content maintainers:
+
+| Feature | Detail | Issue |
+|---------|--------|-------|
+| Line-break insertion | `<?linebreak?>` processing instruction for controlled breaks | #109 |
+| Whitespace visibility | Toggle to see whitespace in Author mode (legacy content used whitespace for layout) | #110 |
+| Surround with PH | Inline text shading/coloring via `<ph>` element wrapping | #111 |
+| xref wrapper removal | Guidance for removing unnecessary xref elements around images | #112 |
+| Author-mode CSS | Custom styling for interactive elements (e.g., enterBtn) in Author view | #155, #156 |
+| DTD management | Managed via OxygenXML project file to avoid relative DTD path references | — |
+
+### Authoring Guidance
+
+A training document need was identified (Issue #4) to provide:
+
+- Background context on the project and its business purpose
+- Description of the business process and publishing pipeline
+- Typical author tasks: adding new pages, updating existing content, managing images
+- DITA conventions specific to Fi3ldMan
+
+## What's New / Change Tracking
+
+### Purpose
+
+Each release of the manual must clearly communicate what content has changed since the previous version.
+
+### Mechanism
+
+| Component | Detail |
+|-----------|--------|
+| Visual markers | Yellow marker images placed next to new or updated content |
+| Version provenance | Each marker records which release version introduced the change |
+| What's New page | Collation page listing all changed entries with links |
+| Bulk removal | Previous release markers must be stripped at each new version |
+| Reference tracking | Changes traced back to source reference spreadsheet IDs |
+
+*Key issues: #7, #124*
+
+## Protective Markings & Security Banners
+
+### Purpose
+
+Every page of every publication must display appropriate security classification, configurable per publication variant and export.
+
+### Implementation
+
+| Element | Detail |
+|---------|--------|
+| Header banner | Security warning text displayed at top of every page |
+| Footer banner | Matching security warning at bottom of every page |
+| Banner color | Configurable per publication/export (e.g., red for classified, blue for commercially sensitive) |
+| Banner text | Configurable (e.g., "COMMERCIALLY SENSITIVE", "RESTRICTED") |
+| Corporate logo | Displayed in header, links to index page |
+| Version info | Branch name and build date shown on welcome page |
+
+*Key issues: #88, #89, #90, #91*
+
+## Content Organization
+
+### Multimedia Management
+
+Content assets are organized into dedicated directories:
+
+| Type | Location | Usage |
+|------|----------|-------|
+| Images | `content/images` | Platform photographs, diagrams, spectrograms |
+| Audio | `content/audio` | Acoustic signature WAV recordings |
+| Video | `content/video` | Propulsion system video recordings |
+
+Embedded audio and video players in published output allow inline playback within class topic pages.
+
+*Key issue: #17*
+
+### Content Hierarchy
+
+The publication content follows a strict geographic/taxonomic hierarchy:
+
+```
+World
+└── Region (e.g., "North Atlantic")
+    └── Country (e.g., "United Kingdom")
+        └── [Category] (optional grouping for nations with many classes)
+            └── Class (e.g., a specific ship/submarine type)
+                ├── Summary (properties table)
+                ├── Signatures (tonals/frequency table)
+                ├── Propulsion
+                ├── Remarks
+                └── Images
+```
+
+Related links exist at both country and class levels, rendered as floating sidebar navigation in published output.
+
+## Publishing Pipeline Summary
+
+| Step | Tool | Output |
+|------|------|--------|
+| Authoring | OxygenXML Editor (Author mode) | DITA XML source |
+| Filtering | DITAVAL + profiling attributes | Filtered DITA for target audience |
+| Transformation | DITA-OT via Oxygen build scenario | WebHelp Responsive HTML |
+| Template | Custom .opt publishing template | Branded output with security banners |
+| Hosting | GitHub Pages / local `serve` | Accessible web publication |


### PR DESCRIPTION
## Summary

- Analyzed ~80 issues and ~55 PRs to extract business use cases, domain requirements, and stakeholder needs not captured in existing context docs (01–06)
- Added four new context documents:
  - **07-business-use-cases-stakeholders.md** — domain context, 6 primary use cases (platform ID, selective publishing, advanced search, change tracking, security, multimedia), stakeholder matrix, domain terminology
  - **08-legacy-migration-strategy.md** — two-phase migration, LegacyMan predecessor, Java applet conversion, data parsing challenges, architecture decisions
  - **09-interactive-features-requirements.md** — requirements & user needs for harmonics calculator, gram viewer, faceted search, table sorting, dark theme (complements existing technical doc 05)
  - **10-content-authoring-publishing-workflows.md** — selective publishing workflow, OxygenXML authoring, What's New tracking, protective markings, publishing pipeline

## Test plan

- [ ] Review documents for factual accuracy against referenced issues/PRs
- [ ] Verify no duplication with existing context docs 01–06
- [ ] Confirm document numbering and naming conventions are consistent